### PR TITLE
Require os specific repo

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -99,6 +99,6 @@ class virtualbox(
 
   package { $package_real:
     ensure  => $version_real,
-    require => Class['virtualbox::repo'],
+    require => Class["virtualbox::repo::$osfamily"],
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -43,7 +43,10 @@ class virtualbox::params {
   }
 
   $repo_release = $::virtualbox_repo_release ? {
-    undef   => $::lsbdistcodename,
+    undef   => $::osfamily ? {
+      'RedHat' => $::operatingsystemrelease,
+      'Debian' => $::lsbdistcodename,
+    },
     default => $::virtualbox_repo_release
   }
 


### PR DESCRIPTION
Without specifying the osfamily option, it attempts to install the package before the repsitory.

```
    E: Unable to locate package virtualbox-4.2
    E: Couldn't find any package by regex 'virtualbox-4.2'

    Error: /Stage[main]/Virtualbox/Package[virtualbox-4.2]/ensure: change from purged to present failed: Execution of '/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold install virtualbox-4.2' returned 100: Reading package lists...
    Building dependency tree...
    Reading state information...
    E: Unable to locate package virtualbox-4.2
    E: Couldn't find any package by regex 'virtualbox-4.2'

    Notice: /Stage[main]/Virtualbox::Repo::Debian/Apt::Source[virtualbox]/Apt::Key[Add key: 98AB5139 from Apt::Source virtualbox]/Exec[01f81ffb7fa3d1f9648ada7fcfa5d72e0f0e7eac]/returns: executed successfully
    Notice: /Stage[main]/Virtualbox::Repo::Debian/Apt::Source[virtualbox]/Apt::Pin[virtualbox]/File[virtualbox.pref]/ensure: created
    Notice: /Stage[main]/Virtualbox::Repo::Debian/Apt::Source[virtualbox]/File[virtualbox.list]/ensure: created
    Notice: /Stage[main]/Apt::Update/Exec[apt_update]: Triggered 'refresh' from 1 events
    Notice: Finished catalog run in 11.11 seconds
```
