### PR TITLE
Add support for linuxmint operatingsystem

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,7 @@
 #   - Fedora Linux
 #   - Debian Linux
 #   - Ubuntu Linux
+#   - Linux Mint
 #
 # === Authors
 #

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -45,7 +45,15 @@ class virtualbox::params {
   $repo_release = $::virtualbox_repo_release ? {
     undef   => $::osfamily ? {
       'RedHat' => $::operatingsystemrelease,
-      'Debian' => $::lsbdistcodename,
+      'Debian' => $::operatingsystem ? {
+        /Ubuntu|Debian/ => $::lsbdistcodename,
+        'LinuxMint'        => $::lsbdistcodename ? {
+          'olivia'  => 'raring',
+          'petra'   => 'saucy',
+          'qiana'   => 'trusty',
+          'default' => fail("LinuxMint ${::lsbdistcodename} is not supported by ${module_name}")
+        }
+      }
     },
     default => $::virtualbox_repo_release
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,10 +16,10 @@ class virtualbox::params {
 
   $repo_baseurl = $::virtualbox_repo_baseurl ? {
     undef   => $::operatingsystem ? {
-      'Fedora'          => 'http://download.virtualbox.org/virtualbox/rpm/fedora/$releasever/$basearch',
-      'Centos'          => 'http://download.virtualbox.org/virtualbox/rpm/rhel/$releasever/$basearch',
-      /(Ubuntu|Debian)/ => 'http://download.virtualbox.org/virtualbox/debian',
-      default           => fail("${::operatingsystem} is not supported by ${module_name}")
+      'Fedora'                    => 'http://download.virtualbox.org/virtualbox/rpm/fedora/$releasever/$basearch',
+      'Centos'                    => 'http://download.virtualbox.org/virtualbox/rpm/rhel/$releasever/$basearch',
+      /(Ubuntu|Debian|LinuxMint)/ => 'http://download.virtualbox.org/virtualbox/debian',
+      default                     => fail("${::operatingsystem} is not supported by ${module_name}")
     },
     default => $::virtualbox_repo_baseurl
   }


### PR DESCRIPTION
Since [facter 2.1.0](https://docs.puppetlabs.com/facter/2.1/release_notes.html), [LinuxMint is now supported](https://docs.puppetlabs.com/facter/2.1/release_notes.html#improvements-to-operating-system-detection) by the `operatingsystem` and `osfamily` facts. Thus the os detection stuff needs to be updated.
